### PR TITLE
Disable pypy builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_numpy1.17python3.6.____cpython:

--- a/.ci_support/linux_64_numpy1.17python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.17python3.6.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 zip_keys:
@@ -40,3 +42,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.17python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.17python3.7.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 zip_keys:
@@ -40,3 +42,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.17python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.17python3.8.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 zip_keys:
@@ -40,3 +42,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 zip_keys:
@@ -40,3 +42,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.17python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.17python3.6.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 zip_keys:
@@ -38,3 +40,4 @@ zip_keys:
   - fortran_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.17python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.17python3.7.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 zip_keys:
@@ -38,3 +40,4 @@ zip_keys:
   - fortran_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.17python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.17python3.8.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 zip_keys:
@@ -38,3 +40,4 @@ zip_keys:
   - fortran_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -30,6 +30,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 zip_keys:
@@ -38,3 +40,4 @@ zip_keys:
   - fortran_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patch-IPOPT-setup-for-conda.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
   skip: True  # [python_impl == 'pypy']
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     - setuptools
 
   commands:
-    - testflo --verbose -n 1 .
+    - testflo --verbose -n 1 --nompi .
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     - setuptools
 
   commands:
-    - testflo --verbose -n 1 --nompi .
+    - testflo --verbose -n 1 --pre_announce .
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 1
   skip: True  # [win]
+  skip: True  # [python_impl == 'pypy']
 
 
 requirements:
@@ -30,7 +31,6 @@ requirements:
     - ipopt
     - libblas
     - liblapack
-    - ipopt
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     - setuptools
 
   commands:
-    - testflo --verbose .
+    - testflo --verbose -n 1 .
     - pip check
 
 about:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Steps:
1. Added the `skip: true [python_impl = 'pypy']`
2. Ran `conda smithy render -c auto`
3. Bumped version number

We'll see if this prevent bots from suggesting pypy PRs in the future (e.g., #3 #4)
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
