### PR TITLE
Fix conda-forge.yml duplicate key that created bot-error during the migrations

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-azure:
-  store_build_artifacts: true
 build_platform:
   osx_arm64: osx_64
 conda_forge_output_validation: true
@@ -8,6 +6,7 @@ github:
   tooling_branch_name: main
 test_on_native_only: true
 azure:
+  store_build_artifacts: true
   settings_win:
     variables:
       SET_PAGEFILE: "True"


### PR DESCRIPTION
In particular, [ipopt3149 migration](https://conda-forge.org/status/#ipopt3149) is failing with bot-error:

> pyoptsparse (0) Error: bot error ([bot CI job](https://github.com/regro/autotick-bot/actions/runs/3027015910)): main: Traceback (most recent call last): File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/auto_tick.py", line 1150, in _run_migrator migrator_uid, pr_json = run( File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/auto_tick.py", line 248, in run migrator.run_post_piggyback_migrations(recipe_dir, feedstock_ctx.attrs, **kwargs) File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/migrators/core.py", line 283, in run_post_piggyback_migrations mini_migrator.migrate(recipe_dir, attrs, **kwargs) File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/migrators/cross_compile.py", line 386, in migrate config = yaml_safe_load(f) File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/utils.py", line 87, in yaml_safe_load return ruamel.yaml.YAML(typ="safe", pure=True).load(stream) File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/main.py", line 434, in load return constructor.get_single_data() File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 121, in get_single_data return self.construct_document(node) File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 131, in construct_document for _dummy in generator: File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 674, in construct_yaml_map value = self.construct_mapping(node) File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 445, in construct_mapping return BaseConstructor.construct_mapping(self, node, deep=deep) File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 263, in construct_mapping if self.check_mapping_key(node, key_node, mapping, key, value): File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 294, in check_mapping_key raise DuplicateKeyError(*args) ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping in "../conda-forge.yml", line 1, column 1 found duplicate key "azure" with value "{}" (original value: "{}") in "../conda-forge.yml", line 10, column 1 To suppress this check see: http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys


I did not bumped the build number or re-rendered as this change is not changing anything, just fixing a syntax error.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
